### PR TITLE
[onkyo] volume dB support for newer Pioneer AVRs (e.g. VSX-1131)

### DIFF
--- a/OnkyoBindingConstants.java
+++ b/OnkyoBindingConstants.java
@@ -1,0 +1,145 @@
+/**
+ * Copyright (c) 2010-2018 by the respective copyright holders.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.openhab.binding.onkyo;
+
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.smarthome.core.thing.ThingTypeUID;
+
+/**
+ * The {@link OnkyoBinding} class defines common constants, which are
+ * used across the whole binding.
+ *
+ * @author Paul Frank - Initial contribution
+ * @author Pauli Anttila
+ */
+@NonNullByDefault
+public class OnkyoBindingConstants {
+
+    public static final String BINDING_ID = "onkyo";
+
+    // List of all supported Onkyo Models
+    public static final String ONKYO_TYPE_TXNR414 = "TX-NR414";
+    public static final String ONKYO_TYPE_TXNR509 = "TX-NR509";
+    public static final String ONKYO_TYPE_TXNR515 = "TX-NR515";
+    public static final String ONKYO_TYPE_TXNR525 = "TX-NR525";
+    public static final String ONKYO_TYPE_TXNR535 = "TX-NR535";
+    public static final String ONKYO_TYPE_TXNR555 = "TX-NR555";
+    public static final String ONKYO_TYPE_TXNR616 = "TX-NR616";
+    public static final String ONKYO_TYPE_TXNR626 = "TX-NR626";
+    public static final String ONKYO_TYPE_TXNR646 = "TX-NR646";
+    public static final String ONKYO_TYPE_TXNR656 = "TX-NR656";
+    public static final String ONKYO_TYPE_TXNR717 = "TX-NR717";
+    public static final String ONKYO_TYPE_TXNR727 = "TX-NR727";
+    public static final String ONKYO_TYPE_TXNR737 = "TX-NR737";
+    public static final String ONKYO_TYPE_TXNR747 = "TX-NR747";
+    public static final String ONKYO_TYPE_TXNR757 = "TX-NR757";
+    public static final String ONKYO_TYPE_TXNR818 = "TX-NR818";
+    public static final String ONKYO_TYPE_TXNR828 = "TX-NR828";
+    public static final String ONKYO_TYPE_TXNR838 = "TX-NR838";
+
+    // List of all supported Pioneer Models
+    public static final String PIONEER_TYPE_VSX1131 = "VSX-1131";
+
+    // Extend this set with all successfully tested models
+    public static final Set<String> SUPPORTED_DEVICE_MODELS = Stream
+            .of(ONKYO_TYPE_TXNR414, ONKYO_TYPE_TXNR509, ONKYO_TYPE_TXNR515, ONKYO_TYPE_TXNR525, ONKYO_TYPE_TXNR535,
+                    ONKYO_TYPE_TXNR555, ONKYO_TYPE_TXNR616, ONKYO_TYPE_TXNR626, ONKYO_TYPE_TXNR646, ONKYO_TYPE_TXNR656,
+                    ONKYO_TYPE_TXNR717, ONKYO_TYPE_TXNR727, ONKYO_TYPE_TXNR737, ONKYO_TYPE_TXNR747, ONKYO_TYPE_TXNR757,
+                    ONKYO_TYPE_TXNR818, ONKYO_TYPE_TXNR828, ONKYO_TYPE_TXNR838, PIONEER_TYPE_VSX1131)
+            .collect(Collectors.toSet());
+
+    // List of all Thing Type UIDs
+    public static final ThingTypeUID THING_TYPE_ONKYOAV = new ThingTypeUID(BINDING_ID, "onkyoAVR");
+    public static final ThingTypeUID THING_TYPE_ONKYO_UNSUPPORTED = new ThingTypeUID(BINDING_ID, "onkyoUnsupported");
+    public static final ThingTypeUID THING_TYPE_TXNR414 = new ThingTypeUID(BINDING_ID, ONKYO_TYPE_TXNR414);
+    public static final ThingTypeUID THING_TYPE_TXNR509 = new ThingTypeUID(BINDING_ID, ONKYO_TYPE_TXNR509);
+    public static final ThingTypeUID THING_TYPE_TXNR515 = new ThingTypeUID(BINDING_ID, ONKYO_TYPE_TXNR515);
+    public static final ThingTypeUID THING_TYPE_TXNR525 = new ThingTypeUID(BINDING_ID, ONKYO_TYPE_TXNR525);
+    public static final ThingTypeUID THING_TYPE_TXNR535 = new ThingTypeUID(BINDING_ID, ONKYO_TYPE_TXNR535);
+    public static final ThingTypeUID THING_TYPE_TXNR555 = new ThingTypeUID(BINDING_ID, ONKYO_TYPE_TXNR555);
+    public static final ThingTypeUID THING_TYPE_TXNR616 = new ThingTypeUID(BINDING_ID, ONKYO_TYPE_TXNR616);
+    public static final ThingTypeUID THING_TYPE_TXNR626 = new ThingTypeUID(BINDING_ID, ONKYO_TYPE_TXNR626);
+    public static final ThingTypeUID THING_TYPE_TXNR646 = new ThingTypeUID(BINDING_ID, ONKYO_TYPE_TXNR646);
+    public static final ThingTypeUID THING_TYPE_TXNR656 = new ThingTypeUID(BINDING_ID, ONKYO_TYPE_TXNR656);
+    public static final ThingTypeUID THING_TYPE_TXNR717 = new ThingTypeUID(BINDING_ID, ONKYO_TYPE_TXNR717);
+    public static final ThingTypeUID THING_TYPE_TXNR727 = new ThingTypeUID(BINDING_ID, ONKYO_TYPE_TXNR727);
+    public static final ThingTypeUID THING_TYPE_TXNR737 = new ThingTypeUID(BINDING_ID, ONKYO_TYPE_TXNR737);
+    public static final ThingTypeUID THING_TYPE_TXNR747 = new ThingTypeUID(BINDING_ID, ONKYO_TYPE_TXNR747);
+    public static final ThingTypeUID THING_TYPE_TXNR757 = new ThingTypeUID(BINDING_ID, ONKYO_TYPE_TXNR757);
+    public static final ThingTypeUID THING_TYPE_TXNR818 = new ThingTypeUID(BINDING_ID, ONKYO_TYPE_TXNR818);
+    public static final ThingTypeUID THING_TYPE_TXNR828 = new ThingTypeUID(BINDING_ID, ONKYO_TYPE_TXNR828);
+    public static final ThingTypeUID THING_TYPE_TXNR838 = new ThingTypeUID(BINDING_ID, ONKYO_TYPE_TXNR838);
+    public static final ThingTypeUID THING_TYPE_VSX1131 = new ThingTypeUID(BINDING_ID, PIONEER_TYPE_VSX1131);
+
+    public static final Set<ThingTypeUID> SUPPORTED_THING_TYPES_UIDS = Stream
+            .of(THING_TYPE_ONKYOAV, THING_TYPE_ONKYO_UNSUPPORTED, THING_TYPE_TXNR414, THING_TYPE_TXNR515,
+                    THING_TYPE_TXNR525, THING_TYPE_TXNR535, THING_TYPE_TXNR555, THING_TYPE_TXNR616, THING_TYPE_TXNR626,
+                    THING_TYPE_TXNR646, THING_TYPE_TXNR656, THING_TYPE_TXNR717, THING_TYPE_TXNR727, THING_TYPE_TXNR737,
+                    THING_TYPE_TXNR747, THING_TYPE_TXNR757, THING_TYPE_TXNR818, THING_TYPE_TXNR828, THING_TYPE_TXNR838,
+                    THING_TYPE_VSX1131)
+            .collect(Collectors.toSet());
+
+    // List of thing parameters names
+    public static final String HOST_PARAMETER = "ipAddress";
+    public static final String TCP_PORT_PARAMETER = "port";
+    public static final String UDN_PARAMETER = "udn";
+    public static final String REFRESH_INTERVAL = "refreshInterval";
+
+    // List of all Channel ids
+    public static final String CHANNEL_POWER = "zone1#power";
+    public static final String CHANNEL_INPUT = "zone1#input";
+    public static final String CHANNEL_MUTE = "zone1#mute";
+    public static final String CHANNEL_VOLUME = "zone1#volume";
+    public static final String CHANNEL_VOLUMEDB = "zone1#volumedb";
+
+    public static final String CHANNEL_POWERZONE2 = "zone2#power";
+    public static final String CHANNEL_INPUTZONE2 = "zone2#input";
+    public static final String CHANNEL_MUTEZONE2 = "zone2#mute";
+    public static final String CHANNEL_VOLUMEZONE2 = "zone2#volume";
+    public static final String CHANNEL_VOLUMEDBZONE2 = "zone2#volumedb";
+
+    public static final String CHANNEL_POWERZONE3 = "zone3#power";
+    public static final String CHANNEL_INPUTZONE3 = "zone3#input";
+    public static final String CHANNEL_MUTEZONE3 = "zone3#mute";
+    public static final String CHANNEL_VOLUMEZONE3 = "zone3#volume";
+    public static final String CHANNEL_VOLUMEDBZONE3 = "zone3#volumedb";
+
+    public static final String CHANNEL_CONTROL = "player#control";
+    public static final String CHANNEL_CURRENTPLAYINGTIME = "player#currentPlayingTime";
+    public static final String CHANNEL_ARTIST = "player#artist";
+    public static final String CHANNEL_TITLE = "player#title";
+    public static final String CHANNEL_ALBUM = "player#album";
+    public static final String CHANNEL_ALBUM_ART = "player#albumArt";
+    public static final String CHANNEL_ALBUM_ART_URL = "player#albumArtUrl";
+    public static final String CHANNEL_LISTENMODE = "player#listenmode";
+    public static final String CHANNEL_PLAY_URI = "player#playuri";
+
+    public static final String CHANNEL_NET_MENU_TITLE = "netmenu#title";
+    public static final String CHANNEL_NET_MENU_CONTROL = "netmenu#control";
+    public static final String CHANNEL_NET_MENU_SELECTION = "netmenu#selection";
+    public static final String CHANNEL_NET_MENU0 = "netmenu#item0";
+    public static final String CHANNEL_NET_MENU1 = "netmenu#item1";
+    public static final String CHANNEL_NET_MENU2 = "netmenu#item2";
+    public static final String CHANNEL_NET_MENU3 = "netmenu#item3";
+    public static final String CHANNEL_NET_MENU4 = "netmenu#item4";
+    public static final String CHANNEL_NET_MENU5 = "netmenu#item5";
+    public static final String CHANNEL_NET_MENU6 = "netmenu#item6";
+    public static final String CHANNEL_NET_MENU7 = "netmenu#item7";
+    public static final String CHANNEL_NET_MENU8 = "netmenu#item8";
+    public static final String CHANNEL_NET_MENU9 = "netmenu#item9";
+
+    // Used for Discovery service
+    public static final String MANUFACTURER = "ONKYO";
+    public static final String UPNP_DEVICE_TYPE = "MediaRenderer";
+
+}

--- a/OnkyoDeviceConfiguration.java
+++ b/OnkyoDeviceConfiguration.java
@@ -1,0 +1,38 @@
+/**
+ * Copyright (c) 2010-2018 by the respective copyright holders.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.openhab.binding.onkyo.internal.config;
+
+/**
+ * Configuration class for {@link OnkyoBinding} device.
+ *
+ * @author Pauli Anttila - Initial contribution
+ */
+public class OnkyoDeviceConfiguration {
+
+    public String ipAddress;
+    public int port;
+    public String udn;
+    public int refreshInterval;
+    public int volumeLimit;
+    public int volumedbLimit;
+
+    @Override
+    public String toString() {
+        String str = "";
+
+        str += "ipAddress = " + ipAddress;
+        str += ", port = " + port;
+        str += ", udn = " + udn;
+        str += ", refreshInterval = " + refreshInterval;
+        str += ", volumeLimit = " + volumeLimit;
+        str += ", volumedbLimit = " + volumedbLimit;
+
+        return str;
+    }
+}

--- a/OnkyoHandler.java
+++ b/OnkyoHandler.java
@@ -1,0 +1,924 @@
+/**
+ * Copyright (c) 2010-2018 by the respective copyright holders.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.openhab.binding.onkyo.handler;
+
+import static org.openhab.binding.onkyo.OnkyoBindingConstants.*;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+
+import org.eclipse.smarthome.core.audio.AudioHTTPServer;
+import org.eclipse.smarthome.core.library.types.DecimalType;
+import org.eclipse.smarthome.core.library.types.IncreaseDecreaseType;
+import org.eclipse.smarthome.core.library.types.NextPreviousType;
+import org.eclipse.smarthome.core.library.types.OnOffType;
+import org.eclipse.smarthome.core.library.types.PercentType;
+import org.eclipse.smarthome.core.library.types.PlayPauseType;
+import org.eclipse.smarthome.core.library.types.RawType;
+import org.eclipse.smarthome.core.library.types.RewindFastforwardType;
+import org.eclipse.smarthome.core.library.types.StringType;
+import org.eclipse.smarthome.core.thing.Channel;
+import org.eclipse.smarthome.core.thing.ChannelUID;
+import org.eclipse.smarthome.core.thing.Thing;
+import org.eclipse.smarthome.core.thing.ThingStatus;
+import org.eclipse.smarthome.core.thing.ThingStatusDetail;
+import org.eclipse.smarthome.core.types.Command;
+import org.eclipse.smarthome.core.types.RefreshType;
+import org.eclipse.smarthome.core.types.State;
+import org.eclipse.smarthome.core.types.UnDefType;
+import org.eclipse.smarthome.io.net.http.HttpUtil;
+import org.eclipse.smarthome.io.transport.upnp.UpnpIOService;
+import org.openhab.binding.onkyo.internal.OnkyoAlbumArt;
+import org.openhab.binding.onkyo.internal.OnkyoConnection;
+import org.openhab.binding.onkyo.internal.OnkyoEventListener;
+import org.openhab.binding.onkyo.internal.ServiceType;
+import org.openhab.binding.onkyo.internal.config.OnkyoDeviceConfiguration;
+import org.openhab.binding.onkyo.internal.eiscp.EiscpCommand;
+import org.openhab.binding.onkyo.internal.eiscp.EiscpMessage;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * The {@link OnkyoHandler} is responsible for handling commands, which are
+ * sent to one of the channels.
+ *
+ * @author Paul Frank - Initial contribution
+ * @author Marcel Verpaalen - parsing additional commands
+ * @author Pauli Anttila - lot of refactoring
+ */
+public class OnkyoHandler extends UpnpAudioSinkHandler implements OnkyoEventListener {
+
+    private Logger logger = LoggerFactory.getLogger(OnkyoHandler.class);
+
+    private OnkyoDeviceConfiguration configuration;
+
+    private OnkyoConnection connection;
+    private ScheduledFuture<?> resourceUpdaterFuture;
+    @SuppressWarnings("unused")
+    private int currentInput = -1;
+    private State volumeLevelZone1 = UnDefType.UNDEF;
+    private State volumeLevelZone2 = UnDefType.UNDEF;
+    private State volumeLevelZone3 = UnDefType.UNDEF;
+    private State volumedbLevelZone1 = UnDefType.UNDEF;
+    private State volumedbLevelZone2 = UnDefType.UNDEF;
+    private State volumedbLevelZone3 = UnDefType.UNDEF;
+
+    private OnkyoAlbumArt onkyoAlbumArt = new OnkyoAlbumArt();
+
+    private final int NET_USB_ID = 43;
+
+    public OnkyoHandler(Thing thing, UpnpIOService upnpIOService, AudioHTTPServer audioHTTPServer, String callbackUrl) {
+        super(thing, upnpIOService, audioHTTPServer, callbackUrl);
+    }
+
+    /**
+     * Initialize the state of the receiver.
+     */
+    @Override
+    public void initialize() {
+        logger.debug("Initializing handler for Onkyo Receiver");
+        configuration = getConfigAs(OnkyoDeviceConfiguration.class);
+        logger.info("Using configuration: {}", configuration.toString());
+
+        connection = new OnkyoConnection(configuration.ipAddress, configuration.port);
+        connection.addEventListener(this);
+
+        scheduler.execute(() -> {
+            logger.debug("Open connection to Onkyo Receiver @{}", connection.getConnectionName());
+            connection.openConnection();
+            if (connection.isConnected()) {
+                updateStatus(ThingStatus.ONLINE);
+            }
+        });
+
+        if (configuration.refreshInterval > 0) {
+            // Start resource refresh updater
+            resourceUpdaterFuture = scheduler.scheduleWithFixedDelay(() -> {
+                try {
+                    logger.debug("Send resource update requests to Onkyo Receiver @{}", connection.getConnectionName());
+                    checkStatus();
+                } catch (LinkageError e) {
+                    logger.warn("Failed to send resource update requests to Onkyo Receiver @{}. Cause: {}",
+                            connection.getConnectionName(), e.getMessage());
+                } catch (Exception ex) {
+                    logger.warn("Exception in resource refresh Thread Onkyo Receiver @{}. Cause: {}",
+                            connection.getConnectionName(), ex.getMessage());
+                }
+            }, configuration.refreshInterval, configuration.refreshInterval, TimeUnit.SECONDS);
+        }
+    }
+
+    @Override
+    public void dispose() {
+        super.dispose();
+        if (resourceUpdaterFuture != null) {
+            resourceUpdaterFuture.cancel(true);
+        }
+        if (connection != null) {
+            connection.removeEventListener(this);
+            connection.closeConnection();
+        }
+    }
+
+    @Override
+    public void handleCommand(ChannelUID channelUID, Command command) {
+        logger.debug("handleCommand for channel {}: {}", channelUID.getId(), command.toString());
+        switch (channelUID.getId()) {
+            /*
+             * ZONE 1
+             */
+
+            case CHANNEL_POWER:
+                if (command instanceof OnOffType) {
+                    sendCommand(EiscpCommand.POWER_SET, command);
+                } else if (command.equals(RefreshType.REFRESH)) {
+                    sendCommand(EiscpCommand.POWER_QUERY);
+                }
+                break;
+            case CHANNEL_MUTE:
+                if (command instanceof OnOffType) {
+                    sendCommand(EiscpCommand.MUTE_SET, command);
+                } else if (command.equals(RefreshType.REFRESH)) {
+                    sendCommand(EiscpCommand.MUTE_QUERY);
+                }
+                break;
+            case CHANNEL_VOLUME:
+                handleVolumeSet(EiscpCommand.Zone.ZONE1, volumeLevelZone1, command);
+                break;
+            case CHANNEL_VOLUMEDB:
+                handleVolumedbSet(EiscpCommand.Zone.ZONE1, volumedbLevelZone1, command);
+                break;
+            case CHANNEL_INPUT:
+                if (command instanceof DecimalType) {
+                    selectInput(((DecimalType) command).intValue());
+                } else if (command.equals(RefreshType.REFRESH)) {
+                    sendCommand(EiscpCommand.SOURCE_QUERY);
+                }
+                break;
+            case CHANNEL_LISTENMODE:
+                if (command instanceof DecimalType) {
+                    sendCommand(EiscpCommand.LISTEN_MODE_SET, command);
+                } else if (command.equals(RefreshType.REFRESH)) {
+                    sendCommand(EiscpCommand.LISTEN_MODE_QUERY);
+                }
+                break;
+
+            /*
+             * ZONE 2
+             */
+
+            case CHANNEL_POWERZONE2:
+                if (command instanceof OnOffType) {
+                    sendCommand(EiscpCommand.ZONE2_POWER_SET, command);
+                } else if (command.equals(RefreshType.REFRESH)) {
+                    sendCommand(EiscpCommand.ZONE2_POWER_QUERY);
+                }
+                break;
+            case CHANNEL_MUTEZONE2:
+                if (command instanceof OnOffType) {
+                    sendCommand(EiscpCommand.ZONE2_MUTE_SET, command);
+                } else if (command.equals(RefreshType.REFRESH)) {
+                    sendCommand(EiscpCommand.ZONE2_MUTE_QUERY);
+                }
+                break;
+            case CHANNEL_VOLUMEZONE2:
+                handleVolumeSet(EiscpCommand.Zone.ZONE2, volumeLevelZone2, command);
+                break;
+            case CHANNEL_VOLUMEDBZONE2:
+                handleVolumedbSet(EiscpCommand.Zone.ZONE2, volumedbLevelZone2, command);
+                break;
+            case CHANNEL_INPUTZONE2:
+                if (command instanceof DecimalType) {
+                    sendCommand(EiscpCommand.ZONE2_SOURCE_SET, command);
+                } else if (command.equals(RefreshType.REFRESH)) {
+                    sendCommand(EiscpCommand.ZONE2_SOURCE_QUERY);
+                }
+                break;
+
+            /*
+             * ZONE 3
+             */
+
+            case CHANNEL_POWERZONE3:
+                if (command instanceof OnOffType) {
+                    sendCommand(EiscpCommand.ZONE3_POWER_SET, command);
+                } else if (command.equals(RefreshType.REFRESH)) {
+                    sendCommand(EiscpCommand.ZONE3_POWER_QUERY);
+                }
+                break;
+            case CHANNEL_MUTEZONE3:
+                if (command instanceof OnOffType) {
+                    sendCommand(EiscpCommand.ZONE3_MUTE_SET, command);
+                } else if (command.equals(RefreshType.REFRESH)) {
+                    sendCommand(EiscpCommand.ZONE3_MUTE_QUERY);
+                }
+                break;
+            case CHANNEL_VOLUMEZONE3:
+                handleVolumeSet(EiscpCommand.Zone.ZONE3, volumeLevelZone3, command);
+                break;
+            case CHANNEL_VOLUMEDBZONE3:
+                handleVolumedbSet(EiscpCommand.Zone.ZONE3, volumedbLevelZone3, command);
+                break;
+            case CHANNEL_INPUTZONE3:
+                if (command instanceof DecimalType) {
+                    sendCommand(EiscpCommand.ZONE3_SOURCE_SET, command);
+                } else if (command.equals(RefreshType.REFRESH)) {
+                    sendCommand(EiscpCommand.ZONE3_SOURCE_QUERY);
+                }
+                break;
+
+            /*
+             * NET PLAYER
+             */
+
+            case CHANNEL_CONTROL:
+                if (command instanceof PlayPauseType) {
+                    if (command.equals(PlayPauseType.PLAY)) {
+                        sendCommand(EiscpCommand.NETUSB_OP_PLAY);
+                    } else if (command.equals(PlayPauseType.PAUSE)) {
+                        sendCommand(EiscpCommand.NETUSB_OP_PAUSE);
+                    }
+                } else if (command instanceof NextPreviousType) {
+                    if (command.equals(NextPreviousType.NEXT)) {
+                        sendCommand(EiscpCommand.NETUSB_OP_TRACKUP);
+                    } else if (command.equals(NextPreviousType.PREVIOUS)) {
+                        sendCommand(EiscpCommand.NETUSB_OP_TRACKDWN);
+                    }
+                } else if (command instanceof RewindFastforwardType) {
+                    if (command.equals(RewindFastforwardType.REWIND)) {
+                        sendCommand(EiscpCommand.NETUSB_OP_REW);
+                    } else if (command.equals(RewindFastforwardType.FASTFORWARD)) {
+                        sendCommand(EiscpCommand.NETUSB_OP_FF);
+                    }
+                } else if (command.equals(RefreshType.REFRESH)) {
+                    sendCommand(EiscpCommand.NETUSB_PLAY_STATUS_QUERY);
+                }
+                break;
+            case CHANNEL_PLAY_URI:
+                handlePlayUri(command);
+                break;
+            case CHANNEL_ALBUM_ART:
+            case CHANNEL_ALBUM_ART_URL:
+                if (command.equals(RefreshType.REFRESH)) {
+                    sendCommand(EiscpCommand.NETUSB_ALBUM_ART_QUERY);
+                }
+                break;
+            case CHANNEL_ARTIST:
+                if (command.equals(RefreshType.REFRESH)) {
+                    sendCommand(EiscpCommand.NETUSB_SONG_ARTIST_QUERY);
+                }
+                break;
+            case CHANNEL_ALBUM:
+                if (command.equals(RefreshType.REFRESH)) {
+                    sendCommand(EiscpCommand.NETUSB_SONG_ALBUM_QUERY);
+                }
+                break;
+            case CHANNEL_TITLE:
+                if (command.equals(RefreshType.REFRESH)) {
+                    sendCommand(EiscpCommand.NETUSB_SONG_TITLE_QUERY);
+                }
+                break;
+            case CHANNEL_CURRENTPLAYINGTIME:
+                if (command.equals(RefreshType.REFRESH)) {
+                    sendCommand(EiscpCommand.NETUSB_SONG_ELAPSEDTIME_QUERY);
+                }
+                break;
+
+            /*
+             * NET MENU
+             */
+
+            case CHANNEL_NET_MENU_CONTROL:
+                if (command instanceof StringType) {
+                    final String cmdName = command.toString();
+                    handleNetMenuCommand(cmdName);
+                }
+                break;
+            case CHANNEL_NET_MENU_TITLE:
+                if (command.equals(RefreshType.REFRESH)) {
+                    sendCommand(EiscpCommand.NETUSB_TITLE_QUERY);
+                }
+                break;
+
+            /*
+             * MISC
+             */
+
+            default:
+                logger.debug("Command received for an unknown channel: {}", channelUID.getId());
+                break;
+        }
+    }
+
+    @Override
+    public void statusUpdateReceived(String ip, EiscpMessage data) {
+        logger.debug("Received status update from Onkyo Receiver @{}: data={}", connection.getConnectionName(), data);
+
+        updateStatus(ThingStatus.ONLINE);
+
+        try {
+            EiscpCommand receivedCommand = null;
+
+            try {
+                receivedCommand = EiscpCommand.getCommandByCommandAndValueStr(data.getCommand(), "");
+            } catch (IllegalArgumentException ex) {
+                logger.debug("Received unknown status update from Onkyo Receiver @{}: data={}",
+                        connection.getConnectionName(), data);
+                return;
+            }
+
+            logger.debug("Received command {}", receivedCommand);
+
+            switch (receivedCommand) {
+                /*
+                 * ZONE 1
+                 */
+                case POWER:
+                    updateState(CHANNEL_POWER, convertDeviceValueToOpenHabState(data.getValue(), OnOffType.class));
+                    break;
+                case MUTE:
+                    updateState(CHANNEL_MUTE, convertDeviceValueToOpenHabState(data.getValue(), OnOffType.class));
+                    break;
+                case VOLUME:
+                    volumeLevelZone1 = handleReceivedVolume(
+                            convertDeviceValueToOpenHabState(data.getValue(), PercentType.class));
+                    updateState(CHANNEL_VOLUME, volumeLevelZone1);
+                    volumedbLevelZone1 = handleReceivedVolume(
+                            convertVolumeValueToOpenHabState(data.getValue(), DecimalType.class));
+                    updateState(CHANNEL_VOLUMEDB, volumedbLevelZone1);
+                    break;
+                case SOURCE:
+                    updateState(CHANNEL_INPUT, convertDeviceValueToOpenHabState(data.getValue(), DecimalType.class));
+                    break;
+                case LISTEN_MODE:
+                    updateState(CHANNEL_LISTENMODE,
+                            convertDeviceValueToOpenHabState(data.getValue(), DecimalType.class));
+                    break;
+
+                /*
+                 * ZONE 2
+                 */
+                case ZONE2_POWER:
+                    updateState(CHANNEL_POWERZONE2, convertDeviceValueToOpenHabState(data.getValue(), OnOffType.class));
+                    break;
+                case ZONE2_MUTE:
+                    updateState(CHANNEL_MUTEZONE2, convertDeviceValueToOpenHabState(data.getValue(), OnOffType.class));
+                    break;
+                case ZONE2_VOLUME:
+                    volumeLevelZone2 = handleReceivedVolume(
+                            convertDeviceValueToOpenHabState(data.getValue(), PercentType.class));
+                    updateState(CHANNEL_VOLUMEZONE2, volumeLevelZone2);
+                    volumedbLevelZone2 = handleReceivedVolume(
+                            convertVolumeValueToOpenHabState(data.getValue(), DecimalType.class));
+                    updateState(CHANNEL_VOLUMEDBZONE2, volumedbLevelZone2);
+                    break;
+                case ZONE2_SOURCE:
+                    updateState(CHANNEL_INPUTZONE2,
+                            convertDeviceValueToOpenHabState(data.getValue(), DecimalType.class));
+                    break;
+
+                /*
+                 * ZONE 3
+                 */
+                case ZONE3_POWER:
+                    updateState(CHANNEL_POWERZONE3, convertDeviceValueToOpenHabState(data.getValue(), OnOffType.class));
+                    break;
+                case ZONE3_MUTE:
+                    updateState(CHANNEL_MUTEZONE3, convertDeviceValueToOpenHabState(data.getValue(), OnOffType.class));
+                    break;
+                case ZONE3_VOLUME:
+                    volumeLevelZone3 = handleReceivedVolume(
+                            convertDeviceValueToOpenHabState(data.getValue(), PercentType.class));
+                    updateState(CHANNEL_VOLUMEZONE3, volumeLevelZone3);
+                    volumedbLevelZone3 = handleReceivedVolume(
+                            convertVolumeValueToOpenHabState(data.getValue(), DecimalType.class));
+                    updateState(CHANNEL_VOLUMEDBZONE3, volumedbLevelZone3);
+                    break;
+                case ZONE3_SOURCE:
+                    updateState(CHANNEL_INPUTZONE3,
+                            convertDeviceValueToOpenHabState(data.getValue(), DecimalType.class));
+                    break;
+
+                /*
+                 * NET PLAYER
+                 */
+
+                case NETUSB_SONG_ARTIST:
+                    updateState(CHANNEL_ARTIST, convertDeviceValueToOpenHabState(data.getValue(), StringType.class));
+                    break;
+                case NETUSB_SONG_ALBUM:
+                    updateState(CHANNEL_ALBUM, convertDeviceValueToOpenHabState(data.getValue(), StringType.class));
+                    break;
+                case NETUSB_SONG_TITLE:
+                    updateState(CHANNEL_TITLE, convertDeviceValueToOpenHabState(data.getValue(), StringType.class));
+                    break;
+                case NETUSB_SONG_ELAPSEDTIME:
+                    updateState(CHANNEL_CURRENTPLAYINGTIME,
+                            convertDeviceValueToOpenHabState(data.getValue(), StringType.class));
+                    break;
+                case NETUSB_PLAY_STATUS:
+                    updateState(CHANNEL_CONTROL, convertNetUsbPlayStatus(data.getValue()));
+                    break;
+                case NETUSB_ALBUM_ART:
+                    updateAlbumArt(data.getValue());
+                    break;
+                case NETUSB_TITLE:
+                    updateNetTitle(data.getValue());
+                    break;
+                case NETUSB_MENU:
+                    updateNetMenu(data.getValue());
+                    break;
+
+                /*
+                 * MISC
+                 */
+
+                case INFO:
+                    logger.debug("Info message: '{}'", data.getValue());
+                    break;
+
+                default:
+                    logger.debug("Received unhandled status update from Onkyo Receiver @{}: data={}",
+                            connection.getConnectionName(), data);
+
+            }
+
+        } catch (Exception ex) {
+            logger.warn("Exception in statusUpdateReceived for Onkyo Receiver @{}. Cause: {}, data received: {}",
+                    connection.getConnectionName(), ex.getMessage(), data);
+        }
+    }
+
+    @Override
+    public void connectionError(String ip, String errorMsg) {
+        logger.debug("Connection error occurred to Onkyo Receiver @{}", ip);
+        updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR, errorMsg);
+    }
+
+    private State convertDeviceValueToOpenHabState(String data, Class<?> classToConvert) {
+        State state = UnDefType.UNDEF;
+
+        try {
+            int index;
+
+            if (data.contentEquals("N/A")) {
+                state = UnDefType.UNDEF;
+
+            } else if (classToConvert == OnOffType.class) {
+                index = Integer.parseInt(data, 16);
+                state = index == 0 ? OnOffType.OFF : OnOffType.ON;
+
+            } else if (classToConvert == DecimalType.class) {
+                index = Integer.parseInt(data, 16);
+                state = new DecimalType(index);
+
+            } else if (classToConvert == PercentType.class) {
+                index = Integer.parseInt(data, 16);
+                state = new PercentType(index);
+
+            } else if (classToConvert == StringType.class) {
+                state = new StringType(data);
+
+            }
+        } catch (Exception e) {
+            logger.debug("Cannot convert value '{}' to data type {}", data, classToConvert);
+        }
+
+        logger.debug("Converted data '{}' to openHAB state '{}' ({})", data, state, classToConvert);
+        return state;
+    }
+
+    private State convertVolumeValueToOpenHabState(String data, Class<?> classToConvert) {
+        State state = UnDefType.UNDEF;
+
+        try {
+            int index;
+            Double index_double;
+
+            if (data.contentEquals("N/A")) {
+                state = UnDefType.UNDEF;
+
+            } else if (classToConvert == DecimalType.class) {
+                index = Integer.parseInt(data, 16);
+                index_double = index * 0.5 - 82;                
+                state = new DecimalType(index_double);
+
+            }
+        } catch (Exception e) {
+            logger.debug("Cannot convert value '{}' to data type {}", data, classToConvert);
+        }
+
+        logger.debug("Converted data '{}' to openHAB state '{}' ({})", data, state, classToConvert);
+        return state;
+    }
+
+    private void handleNetMenuCommand(String cmdName) {
+        if ("Up".equals(cmdName)) {
+            sendCommand(EiscpCommand.NETUSB_OP_UP);
+        } else if ("Down".equals(cmdName)) {
+            sendCommand(EiscpCommand.NETUSB_OP_DOWN);
+        } else if ("Select".equals(cmdName)) {
+            sendCommand(EiscpCommand.NETUSB_OP_SELECT);
+        } else if ("PageUp".equals(cmdName)) {
+            sendCommand(EiscpCommand.NETUSB_OP_LEFT);
+        } else if ("PageDown".equals(cmdName)) {
+            sendCommand(EiscpCommand.NETUSB_OP_RIGHT);
+        } else if ("Back".equals(cmdName)) {
+            sendCommand(EiscpCommand.NETUSB_OP_RETURN);
+        } else if (cmdName.matches("Select[0-9]")) {
+            int pos = Integer.parseInt(cmdName.substring(6));
+            sendCommand(EiscpCommand.NETUSB_MENU_SELECT, new DecimalType(pos));
+        } else {
+            logger.debug("Received unknown menucommand {}", cmdName);
+        }
+    }
+
+    private void selectInput(int inputId) {
+        sendCommand(EiscpCommand.SOURCE_SET, new DecimalType(inputId));
+        currentInput = inputId;
+    }
+
+    @SuppressWarnings("unused")
+    private void onInputChanged(int newInput) {
+        currentInput = newInput;
+
+        if (newInput != NET_USB_ID) {
+            resetNetMenu();
+
+            updateState(CHANNEL_ARTIST, UnDefType.UNDEF);
+            updateState(CHANNEL_ALBUM, UnDefType.UNDEF);
+            updateState(CHANNEL_TITLE, UnDefType.UNDEF);
+            updateState(CHANNEL_CURRENTPLAYINGTIME, UnDefType.UNDEF);
+        }
+    }
+
+    private void updateAlbumArt(String data) {
+        onkyoAlbumArt.addFrame(data);
+
+        if (onkyoAlbumArt.isAlbumCoverReady()) {
+            try {
+                byte[] imgData = onkyoAlbumArt.getAlbumArt();
+                if (imgData != null && imgData.length > 0) {
+                    String mimeType = onkyoAlbumArt.getAlbumArtMimeType();
+                    if (mimeType.isEmpty()) {
+                        mimeType = guessMimeTypeFromData(imgData);
+                    }
+                    updateState(CHANNEL_ALBUM_ART, new RawType(imgData, mimeType));
+                } else {
+                    updateState(CHANNEL_ALBUM_ART, UnDefType.UNDEF);
+                }
+            } catch (IllegalArgumentException e) {
+                updateState(CHANNEL_ALBUM_ART, UnDefType.UNDEF);
+            }
+            onkyoAlbumArt.clearAlbumArt();
+        }
+
+        if (data.startsWith("2-")) {
+            updateState(CHANNEL_ALBUM_ART_URL, new StringType(data.substring(2, data.length())));
+        } else if (data.startsWith("n-")) {
+            updateState(CHANNEL_ALBUM_ART_URL, UnDefType.UNDEF);
+        } else {
+            logger.debug("Not supported album art URL type: {}", data.substring(0, 2));
+            updateState(CHANNEL_ALBUM_ART_URL, UnDefType.UNDEF);
+        }
+
+    }
+
+    private void updateNetTitle(String data) {
+        // first 2 characters is service type
+        int type = Integer.parseInt(data.substring(0, 2), 16);
+        ServiceType service = ServiceType.getType(type);
+
+        String title = "";
+        if (data.length() > 21) {
+            title = data.substring(22, data.length());
+        }
+
+        updateState(CHANNEL_NET_MENU_TITLE,
+                new StringType(service.toString() + ((title.length() > 0) ? ": " + title : "")));
+
+    }
+
+    private void updateNetMenu(String data) {
+        switch (data.charAt(0)) {
+            case 'U':
+                String itemData = data.substring(3, data.length());
+                switch (data.charAt(1)) {
+                    case '0':
+                        updateState(CHANNEL_NET_MENU0, new StringType(itemData));
+                        break;
+                    case '1':
+                        updateState(CHANNEL_NET_MENU1, new StringType(itemData));
+                        break;
+                    case '2':
+                        updateState(CHANNEL_NET_MENU2, new StringType(itemData));
+                        break;
+                    case '3':
+                        updateState(CHANNEL_NET_MENU3, new StringType(itemData));
+                        break;
+                    case '4':
+                        updateState(CHANNEL_NET_MENU4, new StringType(itemData));
+                        break;
+                    case '5':
+                        updateState(CHANNEL_NET_MENU5, new StringType(itemData));
+                        break;
+                    case '6':
+                        updateState(CHANNEL_NET_MENU6, new StringType(itemData));
+                        break;
+                    case '7':
+                        updateState(CHANNEL_NET_MENU7, new StringType(itemData));
+                        break;
+                    case '8':
+                        updateState(CHANNEL_NET_MENU8, new StringType(itemData));
+                        break;
+                    case '9':
+                        updateState(CHANNEL_NET_MENU9, new StringType(itemData));
+                        break;
+                }
+                break;
+
+            case 'C':
+                updateMenuPosition(data);
+                break;
+        }
+    }
+
+    private void updateMenuPosition(String data) {
+        char position = data.charAt(1);
+        int pos = Character.getNumericValue(position);
+
+        logger.debug("Updating menu position to {}", pos);
+
+        if (pos == -1) {
+            updateState(CHANNEL_NET_MENU_SELECTION, UnDefType.UNDEF);
+        } else {
+            updateState(CHANNEL_NET_MENU_SELECTION, new DecimalType(pos));
+        }
+
+        if (data.endsWith("P")) {
+            resetNetMenu();
+        }
+    }
+
+    private void resetNetMenu() {
+        logger.debug("Reset net menu");
+        updateState(CHANNEL_NET_MENU0, new StringType("-"));
+        updateState(CHANNEL_NET_MENU1, new StringType("-"));
+        updateState(CHANNEL_NET_MENU2, new StringType("-"));
+        updateState(CHANNEL_NET_MENU3, new StringType("-"));
+        updateState(CHANNEL_NET_MENU4, new StringType("-"));
+        updateState(CHANNEL_NET_MENU5, new StringType("-"));
+        updateState(CHANNEL_NET_MENU6, new StringType("-"));
+        updateState(CHANNEL_NET_MENU7, new StringType("-"));
+        updateState(CHANNEL_NET_MENU8, new StringType("-"));
+        updateState(CHANNEL_NET_MENU9, new StringType("-"));
+    }
+
+    private State convertNetUsbPlayStatus(String data) {
+        State state = UnDefType.UNDEF;
+        switch (data.charAt(0)) {
+            case 'P':
+                state = PlayPauseType.PLAY;
+                break;
+            case 'p':
+            case 'S':
+                state = PlayPauseType.PAUSE;
+                break;
+            case 'F':
+                state = RewindFastforwardType.FASTFORWARD;
+                break;
+            case 'R':
+                state = RewindFastforwardType.REWIND;
+                break;
+
+        }
+        return state;
+    }
+
+    private void sendCommand(EiscpCommand deviceCommand) {
+        if (connection != null) {
+            connection.send(deviceCommand.getCommand(), deviceCommand.getValue());
+        } else {
+            logger.debug("Connect send command to onkyo receiver since the onkyo binding is not initialized");
+        }
+    }
+
+    private void sendCommand(EiscpCommand deviceCommand, Command command) {
+        if (connection != null) {
+            final String cmd = deviceCommand.getCommand();
+            String valTemplate = deviceCommand.getValue();
+            String val;
+
+            if (command instanceof OnOffType) {
+                val = String.format(valTemplate, command == OnOffType.ON ? 1 : 0);
+
+            } else if (command instanceof StringType) {
+                val = String.format(valTemplate, command);
+
+            } else if (command instanceof DecimalType) {
+                val = String.format(valTemplate, ((DecimalType) command).intValue());
+
+            } else if (command instanceof PercentType) {
+                val = String.format(valTemplate, ((DecimalType) command).intValue());
+            } else {
+                val = valTemplate;
+            }
+
+            logger.debug("Sending command '{}' with value '{}' to Onkyo Receiver @{}", cmd, val,
+                    connection.getConnectionName());
+            connection.send(cmd, val);
+        } else {
+            logger.debug("Connect send command to onkyo receiver since the onkyo binding is not initialized");
+        }
+    }
+
+    /**
+     * Check the status of the AVR.
+     *
+     * @return
+     */
+    private void checkStatus() {
+        sendCommand(EiscpCommand.POWER_QUERY);
+
+        if (connection != null && connection.isConnected()) {
+            sendCommand(EiscpCommand.VOLUME_QUERY);
+            sendCommand(EiscpCommand.SOURCE_QUERY);
+            sendCommand(EiscpCommand.MUTE_QUERY);
+            sendCommand(EiscpCommand.NETUSB_TITLE_QUERY);
+            sendCommand(EiscpCommand.LISTEN_MODE_QUERY);
+
+            if (isChannelAvailable(CHANNEL_POWERZONE2)) {
+                sendCommand(EiscpCommand.ZONE2_POWER_QUERY);
+                sendCommand(EiscpCommand.ZONE2_VOLUME_QUERY);
+                sendCommand(EiscpCommand.ZONE2_SOURCE_QUERY);
+                sendCommand(EiscpCommand.ZONE2_MUTE_QUERY);
+            }
+
+            if (isChannelAvailable(CHANNEL_POWERZONE3)) {
+                sendCommand(EiscpCommand.ZONE3_POWER_QUERY);
+                sendCommand(EiscpCommand.ZONE3_VOLUME_QUERY);
+                sendCommand(EiscpCommand.ZONE3_SOURCE_QUERY);
+                sendCommand(EiscpCommand.ZONE3_MUTE_QUERY);
+            }
+        } else {
+            updateStatus(ThingStatus.OFFLINE);
+        }
+    }
+
+    private boolean isChannelAvailable(String channel) {
+        List<Channel> channels = getThing().getChannels();
+        for (Channel c : channels) {
+            if (c.getUID().getId().equals(channel)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private void handleVolumeSet(EiscpCommand.Zone zone, final State currentValue, final Command command) {
+        if (command instanceof PercentType) {
+            sendCommand(EiscpCommand.getCommandForZone(zone, EiscpCommand.VOLUME_SET),
+                    downScaleVolume((PercentType) command));
+        } else if (command.equals(IncreaseDecreaseType.INCREASE)) {
+            if (currentValue instanceof PercentType) {
+                if (((DecimalType) currentValue).intValue() < configuration.volumeLimit) {
+                    sendCommand(EiscpCommand.getCommandForZone(zone, EiscpCommand.VOLUME_UP));
+                } else {
+                    logger.info("Volume level is limited to {}, ignore volume up command.", configuration.volumeLimit);
+                }
+            }
+        } else if (command.equals(IncreaseDecreaseType.DECREASE)) {
+            sendCommand(EiscpCommand.getCommandForZone(zone, EiscpCommand.VOLUME_DOWN));
+        } else if (command.equals(OnOffType.OFF)) {
+            sendCommand(EiscpCommand.getCommandForZone(zone, EiscpCommand.MUTE_SET), command);
+        } else if (command.equals(OnOffType.ON)) {
+            sendCommand(EiscpCommand.getCommandForZone(zone, EiscpCommand.MUTE_SET), command);
+        } else if (command.equals(RefreshType.REFRESH)) {
+            sendCommand(EiscpCommand.getCommandForZone(zone, EiscpCommand.VOLUME_QUERY));
+            sendCommand(EiscpCommand.getCommandForZone(zone, EiscpCommand.MUTE_QUERY));
+        }
+    }
+
+    private State handleReceivedVolume(State volume) {
+        if (volume instanceof PercentType) {
+            return upScaleVolume(((PercentType) volume));
+        }
+        return volume;
+    }
+
+    private PercentType upScaleVolume(PercentType volume) {
+        PercentType newVolume = volume;
+
+        if (configuration.volumeLimit < 100) {
+            double scaleCoefficient = 100d / configuration.volumeLimit;
+            newVolume = new PercentType(((Double) (volume.doubleValue() * scaleCoefficient)).intValue());
+            logger.debug("Up scaled volume level '{}' to '{}'", volume, newVolume);
+        }
+
+        return newVolume;
+    }
+
+    private PercentType downScaleVolume(PercentType volume) {
+        PercentType newVolume = volume;
+
+        if (configuration.volumeLimit < 100) {
+            double scaleCoefficient = configuration.volumeLimit / 100d;
+            newVolume = new PercentType(((Double) (volume.doubleValue() * scaleCoefficient)).intValue());
+            logger.debug("Down scaled volume level '{}' to '{}'", volume, newVolume);
+        }
+
+        return newVolume;
+    }
+
+    @Override
+    public PercentType getVolume() throws IOException {
+        if (volumeLevelZone1 instanceof PercentType) {
+            return (PercentType) volumeLevelZone1;
+        }
+
+        throw new IOException();
+    }
+
+    @Override
+    public void setVolume(PercentType volume) throws IOException {
+        handleVolumeSet(EiscpCommand.Zone.ZONE1, volumeLevelZone1, downScaleVolume(volume));
+    }
+    
+    private void handleVolumedbSet(EiscpCommand.Zone zone, final State currentValue, final Command command) {
+        if (command instanceof DecimalType) {
+            sendCommand(EiscpCommand.getCommandForZone(zone, EiscpCommand.VOLUME_SET),
+                    convertVolumedbToDecimal(downScaleVolumedb((DecimalType) command)));
+        } else if (command.equals(IncreaseDecreaseType.INCREASE)) {
+            if (currentValue instanceof DecimalType) {
+                if (((DecimalType) currentValue).intValue() < configuration.volumedbLimit) {
+                    sendCommand(EiscpCommand.getCommandForZone(zone, EiscpCommand.VOLUME_UP));
+                } else {
+                    logger.info("Volume level is limited to {}, ignore volume up command.", configuration.volumedbLimit);
+                }
+            }
+        } else if (command.equals(IncreaseDecreaseType.DECREASE)) {
+            sendCommand(EiscpCommand.getCommandForZone(zone, EiscpCommand.VOLUME_DOWN));
+        } else if (command.equals(OnOffType.OFF)) {
+            sendCommand(EiscpCommand.getCommandForZone(zone, EiscpCommand.MUTE_SET), command);
+        } else if (command.equals(OnOffType.ON)) {
+            sendCommand(EiscpCommand.getCommandForZone(zone, EiscpCommand.MUTE_SET), command);
+        } else if (command.equals(RefreshType.REFRESH)) {
+            sendCommand(EiscpCommand.getCommandForZone(zone, EiscpCommand.VOLUME_QUERY));
+            sendCommand(EiscpCommand.getCommandForZone(zone, EiscpCommand.MUTE_QUERY));
+        }
+    }
+
+    private DecimalType downScaleVolumedb(DecimalType volumedb) {
+        DecimalType newVolumedb = volumedb;
+
+        if (configuration.volumeLimit < 100) {
+            double scaleCoefficient = configuration.volumeLimit / 100d;
+            newVolumedb = new PercentType(((Double) (volumedb.doubleValue() * scaleCoefficient)).intValue());
+            logger.debug("Down scaled volume level '{}' to '{}'", volumedb, newVolumedb);
+        }
+
+        if (((DecimalType) newVolumedb).intValue() > configuration.volumedbLimit) {
+            newVolumedb = new DecimalType(configuration.volumedbLimit);
+            logger.debug("Down scaled volume level '{}' to '{}'", volumedb, newVolumedb);
+        }
+
+        return newVolumedb;
+    }
+
+    public DecimalType getVolumedb() throws IOException {
+        if (volumedbLevelZone1 instanceof DecimalType) {
+            return (DecimalType) volumedbLevelZone1;
+        }
+
+        throw new IOException();
+    }
+
+    public void setVolumedb(DecimalType volumedb) throws IOException {
+        handleVolumedbSet(EiscpCommand.Zone.ZONE1, volumedbLevelZone1, downScaleVolumedb(volumedb));
+    }
+
+    private DecimalType convertVolumedbToDecimal(DecimalType newVolume) {
+        double tempVolume = newVolume.doubleValue();
+        tempVolume = (tempVolume + 82) * 2;
+        newVolume = new DecimalType(tempVolume);   
+        return newVolume;
+    }
+    
+    private String guessMimeTypeFromData(byte[] data) {
+        String mimeType = HttpUtil.guessContentTypeFromData(data);
+        logger.debug("Mime type guess from content: {}", mimeType);
+        if (mimeType == null) {
+            mimeType = RawType.DEFAULT_MIME_TYPE;
+        }
+        logger.debug("Mime type: {}", mimeType);
+        return mimeType;
+    }
+}

--- a/README.md
+++ b/README.md
@@ -1,18 +1,272 @@
-## openHAB 2 Add-ons
+# Onkyo Binding
 
-This repository contains add-ons that are implemented using the new [Eclipse SmartHome APIs](https://www.eclipse.org/smarthome/documentation/development/bindings/how-to.html) of openHAB 2.
+This binding integrates the Onkyo AV receivers.
 
-Note that all information about openHAB itself, the IDE setup and the contribution processes can be found in the [openhab-distro](https://github.com/openhab/openhab-distro) project, so please go there for any further details!
+## Introduction
 
-## Add-ons in other repositories
-Some add-ons (e.g. specific bindings such as [Z-Wave](https://github.com/openhab/org.openhab.binding.zwave)) are maintained in separate repositories in order to improve their management. In order to contribute to these bindings, you should follow the following steps -:
+Binding should be compatible with Onkyo AV receivers which support ISCP (Integra Serial Control Protocol) over Ethernet (eISCP).
 
-1. Fork the repository on Github
-2. Clone your repository to your local computer as described in the [Github tutorial](https://help.github.com/articles/cloning-a-repository/)
-3. Open the openHAB Eclipse IDE
-4. Select the *File | Import* menu option
-5. Select *General | Existing Projects into Workspace* and click Next
-6. Select the root directory where you made the local clone of the repository
-7. Select the project and click *Next*
-8. The project will now be imported and available in the Package Explorer
-9. You may want to add the project to the *OH2 Add-ons* Working Set
+## Supported Things
+
+This binding supports only one thing: The Onkyo AV Receiver.  All supported Onkyo devices are registered as an audio sink in the framework.
+
+## Discovery
+
+This binding can discover the supported Onkyo AV Receivers. At the moment only the following models are supported:
+
+-   TX-NR414
+-   TX-NR509
+-   TX-NR515
+-   TX-NR525
+-   TX-NR535
+-   TX-NR555
+-   TX-NR535
+-   TX-NR616
+-   TX-NR626
+-   TX-NR636
+-   TX-NR646
+-   TX-NR656
+-   TX-NR717
+-   TX-NR727
+-   TX-NR737
+-   TX-NR747
+-   TX-NR818
+-   TX-NR828
+-   TX-NR838
+
+This binding also discover the supported newer Pioneer AV Reveicers (since 2015)
+
+-   VSX-1131
+
+## Binding Configuration
+
+The binding can auto-discover the Onkyo AVRs present on your local network.
+The auto-discovery is enabled by default.
+To disable it, you can create a file in the services directory called onkyo.cfg with the following content:
+
+```text
+org.openhab.onkyo:enableAutoDiscovery=false
+```
+
+This configuration parameter only controls the Onkyo AVR auto-discovery process, not the openHAB auto-discovery.
+Moreover, if the openHAB auto-discovery is disabled, the Onkyo AVR auto-discovery is disabled too.
+
+
+The binding has the following configuration options, which can be set for "binding:onkyo":
+
+| Parameter   | Name         | Description                                                              | Required |
+|-------------|--------------|--------------------------------------------------------------------------|----------|
+| callbackUrl | Callback URL | URL to use for playing notification sounds, e.g. <http://192.168.0.2:8080> | no       |
+
+## Thing Configuration
+
+The Onkyo AVR thing requires the ip address and the port to access it on.
+In the code `avr-livingroom` refers to the user defined unique id of your Onkyo device. A second device could be called avr2.
+In the thing file, this looks e.g. like
+
+Model specific
+
+```text
+onkyo:TX-NR818:avr-livingroom [ipAddress="192.168.1.100", port=60128]
+```
+
+or
+
+Generic model
+
+```text
+onkyo:onkyoAVR:avr-livingroom [ipAddress="192.168.1.100", port=60128]
+```
+
+Optionally you can specify the refresh interval by refreshInterval parameter.
+
+```text
+onkyo:onkyoAVR:avr-livingroom [ipAddress="192.168.1.100", port=60128, refreshInterval=30]
+```
+
+Maximum volume level can also be configured by volumeLimit parameter.
+This prevent setting receiver volume level too high, which could damage your speakers or receiver.
+
+```text
+onkyo:onkyoAVR:avr-livingroom [ipAddress="192.168.1.100", port=60128, volumeLimit=50]
+```
+
+Binding then automatically scale the volume level in both directions (100% = 50 = 100%).
+
+Newer Pioneer AV Reveicers (since 2015) have volume range from decimal 0 to 200 (Hex 00 to C8) in steps of 0.5dB.
+(e.g. Pioneer VSX-1131 volume range is -82dB to 0dB -> decimal 0 to 164; Hex 00 to A4)
+Maximum volume level can be configured by volumedbLimit parameter.
+This prevent setting receiver volume level too high, which could damage your speakers or receiver.
+
+```text
+onkyo:onkyoAVR:avr-livingroom [ipAddress="192.168.1.100", port=60128, volumedbLimit=-20]
+```
+
+Binding then automatically scale the max volume level to -20dB.
+
+## Channels
+
+The Onkyo AVR supports the following channels (some channels are model specific):
+
+| Channel Type ID           | Item Type | Description                                                                                                      |
+|---------------------------|-----------|------------------------------------------------------------------------------------------------------------------|
+| zone1#power               | Switch    | Power on/off your device                                                                                         |
+| zone1#mute                | Switch    | Mute/unmute zone 1                                                                                               |
+| zone1#input               | Number    | The input for zone 1                                                                                             |
+| zone1#volume              | Dimmer    | Volume of zone 1                                                                                                 |
+| zone1#volumedb            | Number    | Volume (dB) of zone 1                                                                                            |
+| zone2#power               | Switch    | Power on/off zone 2                                                                                              |
+| zone2#mute                | Switch    | Mute/unmute zone 2                                                                                               |
+| zone2#input               | Number    | The input for zone 2                                                                                             |
+| zone2#volume              | Dimmer    | Volume of zone 2                                                                                                 |
+| zone2#volumedb            | Number    | Volume (dB) of zone 2                                                                                            |
+| zone3#power               | Switch    | Power on/off zone 3                                                                                              |
+| zone3#mute                | Switch    | Mute/unmute zone 3                                                                                               |
+| zone3#input               | Number    | The input for zone 3                                                                                             |
+| zone3#volume              | Dimmer    | Volume of zone 3                                                                                                 |
+| zone3#volumedb            | Number    | Volume (dB) of zone 3                                                                                            |
+| player#control            | Player    | Control the Zone Player, e.g.  play/pause/next/previous/ffward/rewind (available if playing from Network or USB) |
+| player#title              | String    | Title of the current song (available if playing from Network or USB)                                             |
+| player#album              | String    | Album name of the current song (available if playing from Network or USB)                                        |
+| player#artist             | String    | Artist name of the current song (available if playing from Network or USB)                                       |
+| player#currentPlayingTime | String    | Current playing time of the current song (available if playing from Network or USB)                              |
+| player#listenmode         | Number    | Current listening mode e.g. Stereo, 5.1ch Surround,..                                                            |
+| player#playuri            | String    | Plays the URI provided to the channel                                                                            |
+| player#albumArt           | Image     | Image of the current album art of the current song                                                               |
+| player#albumArtUrl        | String    | Url to the current album art of the current song                                                                 |
+| netmenu#title             | String    | Title of the current NET service                                                                                 |
+| netmenu#control           | String    | Control the USB/Net Menu, e.g. Up/Down/Select/Back/PageUp/PageDown/Select&lsqb0-9&rsqb                                   |
+| netmenu#selection         | Number    | The number of the currently selected USB/Net Menu entry (0-9)                                                    |
+| netmenu#item0             | String    | The text of USB/Net Menu entry 0                                                                                 |
+| netmenu#item1             | String    | The text of USB/Net Menu entry 1                                                                                 |
+| netmenu#item2             | String    | The text of USB/Net Menu entry 2                                                                                 |
+| netmenu#item3             | String    | The text of USB/Net Menu entry 3                                                                                 |
+| netmenu#item4             | String    | The text of USB/Net Menu entry 4                                                                                 |
+| netmenu#item5             | String    | The text of USB/Net Menu entry 5                                                                                 |
+| netmenu#item6             | String    | The text of USB/Net Menu entry 6                                                                                 |
+| netmenu#item7             | String    | The text of USB/Net Menu entry 7                                                                                 |
+| netmenu#item8             | String    | The text of USB/Net Menu entry 8                                                                                 |
+| netmenu#item9             | String    | The text of USB/Net Menu entry 9                                                                                 |
+
+## Input Source Mapping
+
+Here after are the ID values of the input sources:
+
+-   00: DVR/VCR
+-   01: SATELLITE/CABLE
+-   02: GAME
+-   03: AUX
+-   04: GAME
+-   05: PC
+-   16: BLURAY/DVD
+-   32: TAPE1
+-   33: TAPE2
+-   34: PHONO
+-   35: CD
+-   36: FM
+-   37: AM
+-   38: TUNER
+-   39: MUSICSERVER
+-   40: INTERNETRADIO
+-   41: USB
+-   42: USB_BACK
+-   43: NETWORK
+-   45: AIRPLAY
+-   48: MULTICH
+-   50: SIRIUS
+
+## Item Configuration
+
+demo.items
+
+```java
+Switch avrLrZ1_Power    "Power"       <switch>      { channel="onkyo:onkyoAVR:avr-livingroom:zone1#power" }
+Switch avrLrZ1_Mute     "Mute"        <soundvolume> { channel="onkyo:onkyoAVR:avr-livingroom:zone1#mute" }
+Number avrLrZ1_Input    "Input [%s]"  <text>        { channel="onkyo:onkyoAVR:avr-livingroom:zone1#input" }
+Dimmer avrLrZ1_Volume   "Volume [%d]" <soundvolume> { channel="onkyo:onkyoAVR:avr-livingroom:zone1#volume" }
+Number avrLrZ1_Volumedb "Volume [%.1f dB]" <soundvolume> { channel="onkyo:onkyoAVR:avr-livingroom:zone1#volumedb" }
+
+Switch avrLrZ2_Power    "Power [%s]"  <switch>      { channel="onkyo:onkyoAVR:avr-livingroom:zone2#power" }
+Switch avrLrZ2_Mute     "Mute [%s]"                 { channel="onkyo:onkyoAVR:avr-livingroom:zone2#mute" }
+Number avrLrZ2_Input    "Input [%s]"  <text>        { channel="onkyo:onkyoAVR:avr-livingroom:zone2#input" }
+Dimmer avrLrZ2_Volume   "Volume [%s]" <soundvolume> { channel="onkyo:onkyoAVR:avr-livingroom:zone2#volume" }
+Number avrLrZ2_Volumedb "Volume [%.1f dB]" <soundvolume> { channel="onkyo:onkyoAVR:avr-livingroom:zone2#volumedb" }
+
+Player avrLrPlayer_Control            "Control"                 <text>        { channel="onkyo:onkyoAVR:avr-livingroom:player#control" }
+String avrLrPlayer_Title              "Title [%s]"              <text>        { channel="onkyo:onkyoAVR:avr-livingroom:player#title" }
+String avrLrPlayer_Album              "Album [%s]"              <text>        { channel="onkyo:onkyoAVR:avr-livingroom:player#album" }
+String avrLrPlayer_Artist             "Artist [%s]"             <parents_2_5> { channel="onkyo:onkyoAVR:avr-livingroom:player#artist" }
+String avrLrPlayer_CurrentPlayingTime "CurrentPlayingTime [%s]" <clock>       { channel="onkyo:onkyoAVR:avr-livingroom:player#currentPlayingTime" }
+Number avrLrPlayer_Listenmode         "Listenmode [%d]"         <text>        { channel="onkyo:onkyoAVR:avr-livingroom:player#listenmode" }
+String avrLrPlayer_PlayURI            "PlayURI [%s]"            <text>        { channel="onkyo:onkyoAVR:avr-livingroom:player#playuri" }
+Image  avrLrPlayer_AlbumArt           "AlbumArt [%s]"           <text>        { channel="onkyo:onkyoAVR:avr-livingroom:player#albumArt" }
+String avrLrPlayer_AlbumArtUrl        "AlbumArtUrl [%s]"        <text>        { channel="onkyo:onkyoAVR:avr-livingroom:player#albumArtUrl" }
+
+String avrLrNet_Title     "Title [%s]"     <text>   { channel="onkyo:onkyoAVR:avr-livingroom:netmenu#title" }
+String avrLrNet_Control   "Control"        <text>   { channel="onkyo:onkyoAVR:avr-livingroom:netmenu#control" }
+Number avrLrNet_Selection "Selection [%d]" <text>   { channel="onkyo:onkyoAVR:avr-livingroom:netmenu#selection" }
+String avrLrNet_Item0     "Item0 [%s]"     <text>   { channel="onkyo:onkyoAVR:avr-livingroom:netmenu#item0" }
+String avrLrNet_Item1     "Item1 [%s]"     <text>   { channel="onkyo:onkyoAVR:avr-livingroom:netmenu#item1" }
+String avrLrNet_Item2     "Item2 [%s]"     <text>   { channel="onkyo:onkyoAVR:avr-livingroom:netmenu#item2" }
+String avrLrNet_Item3     "Item3 [%s]"     <text>   { channel="onkyo:onkyoAVR:avr-livingroom:netmenu#item3" }
+String avrLrNet_Item4     "Item4 [%s]"     <text>   { channel="onkyo:onkyoAVR:avr-livingroom:netmenu#item4" }
+String avrLrNet_Item5     "Item5 [%s]"     <text>   { channel="onkyo:onkyoAVR:avr-livingroom:netmenu#item5" }
+String avrLrNet_Item6     "Item6 [%s]"     <text>   { channel="onkyo:onkyoAVR:avr-livingroom:netmenu#item6" }
+String avrLrNet_Item7     "Item7 [%s]"     <text>   { channel="onkyo:onkyoAVR:avr-livingroom:netmenu#item7" }
+String avrLrNet_Item8     "Item8 [%s]"     <text>   { channel="onkyo:onkyoAVR:avr-livingroom:netmenu#item8" }
+String avrLrNet_Item9     "Item9 [%s]"     <text>   { channel="onkyo:onkyoAVR:avr-livingroom:netmenu#item9" }
+```
+
+## Sitemap Configuration
+
+demo.sitemap
+
+```perl
+sitemap demo label="Onkyo AVR"
+{
+    Frame label="Zone1" {
+        Switch    item=avrLrZ1_Power
+        Switch    item=avrLrZ1_Mute
+        Selection item=avrLrZ1_Input  mappings=[ 0='DVR/VCR', 1='SATELLITE/CABLE', 2='GAME', 3='AUX', 4='GAME', 5='PC', 16='BLURAY/DVD', 32='TAPE1', 33='TAPE2', 34='PHONO', 35='CD', 36='FM', 37='AM', 38='TUNER', 39='MUSICSERVER', 40='INTERNETRADIO', 41='USB', 42='USB_BACK', 43='NETWORK', 45='AIRPLAY', 48='MULTICH', 50='SIRIUS' ]
+        Slider    item=avrLrZ1_Volume
+		Setpoint  item=avrLrZ1_Volumedb label="Volume [%.1f dB]" minValue=-82 maxValue=0 step=0.5
+    }
+
+    Frame label="Zone 2" {
+        Switch    item=avrLrZ2_Power
+        Switch    item=avrLrZ2_Mute
+        Selection item=avrLrZ2_Input  mappings=[ 0='DVR/VCR', 1='SATELLITE/CABLE', 2='GAME', 3='AUX', 4='GAME', 5='PC', 16='BLURAY/DVD', 32='TAPE1', 33='TAPE2', 34='PHONO', 35='CD', 36='FM', 37='AM', 38='TUNER', 39='MUSICSERVER', 40='INTERNETRADIO', 41='USB', 42='USB_BACK', 43='NETWORK', 45='AIRPLAY', 48='MULTICH', 50='SIRIUS' ]
+        Slider    item=avrLrZ2_Volume
+		Setpoint  item=avrLrZ2_Volumedb label="Volume [%.1f dB]" minValue=-82 maxValue=0 step=0.5
+    }
+
+    Frame label="Player" {
+        Default   item=avrLrPlayer_Control
+        Text      item=avrLrPlayer_Title
+        Text      item=avrLrPlayer_Album
+        Text      item=avrLrPlayer_Artist
+        Text      item=avrLrPlayer_CurrentPlayingTime
+        Selection item=avrLrPlayer_Listenmode mappings=[0=Stereo, 1=Direct, 2=Surround, 15=Mono, 31="Whole House", 66="THX Cinema"]
+    }
+    Frame label="NetMenu" {
+        Text      item=avrLrNet_Title
+        Selection item=avrLrNet_Control   mappings=[ Up='Up', Down='Down', Select='Select', Back='Back', PageUp='PageUp', PageDown='PageDow', Select0='Select0', Select1='Select1', Select2='Select2', Select3='Select3', Select4='Select4', Select5='Select5', Select6='Select6', Select7='Select7', Select8='Select8', Select9='Select9' ]
+        Selection item=avrLrNet_Selection mappings=[ 0='Item0', 1='Item1', 2='Item2', 3='Item3', 4='Item4', 5='Item5', 6='Item6', 7='Item7', 8='Item8', 9='Item9' ]
+        Text      item=avrLrNet_Item0
+        Text      item=avrLrNet_Item1
+        Text      item=avrLrNet_Item2
+        Text      item=avrLrNet_Item3
+        Text      item=avrLrNet_Item4
+        Text      item=avrLrNet_Item5
+        Text      item=avrLrNet_Item6
+        Text      item=avrLrNet_Item7
+        Text      item=avrLrNet_Item8
+        Text      item=avrLrNet_Item9
+    }
+}
+```
+
+## Audio Support
+
+All supported Onkyo AVRs are registered as an audio sink in the framework.
+Audio streams are sent to the `playuri` channel.

--- a/channel-groups.xml
+++ b/channel-groups.xml
@@ -1,0 +1,105 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<thing:thing-descriptions bindingId="onkyo" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:thing="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0"
+	xsi:schemaLocation="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0 http://eclipse.org/smarthome/schemas/thing-description-1.0.0.xsd">
+
+	<!-- Channel Groups -->
+
+	<channel-group-type id="zone1Controls">
+		<label>Zone 1 (Main Zone)</label>
+		<channels>
+			<channel id="power" typeId="power" />
+			<channel id="input" typeId="input" />
+			<channel id="volume" typeId="volume" />
+			<channel id="volumedb" typeId="volumedb" />
+			<channel id="mute" typeId="mute" />
+		</channels>
+	</channel-group-type>
+
+	<channel-group-type id="zone2Controls">
+		<label>Zone 2</label>
+		<channels>
+			<channel id="power" typeId="power" />
+			<channel id="input" typeId="input" />
+			<channel id="volume" typeId="volume" />
+			<channel id="volumedb" typeId="volumedb" />
+			<channel id="mute" typeId="mute" />
+		</channels>
+	</channel-group-type>
+
+	<channel-group-type id="zone3Controls">
+		<label>Zone 3</label>
+		<channels>
+			<channel id="power" typeId="power" />
+			<channel id="input" typeId="input" />
+			<channel id="volume" typeId="volume" />
+			<channel id="volumedb" typeId="volumedb" />
+			<channel id="mute" typeId="mute" />
+		</channels>
+	</channel-group-type>
+
+	<channel-group-type id="playerControls">
+		<label>Player</label>
+		<channels>
+			<channel id="control" typeId="control" />
+			<channel id="currentPlayingTime" typeId="currentPlayingTime" />
+			<channel id="title" typeId="title" />
+			<channel id="album" typeId="album" />
+			<channel id="artist" typeId="artist" />
+			<channel id="listenmode" typeId="listenmode" />
+			<channel id="playuri" typeId="playuri" />
+			<channel id="albumArt" typeId="albumArt" />
+			<channel id="albumArtUrl" typeId="albumArtUrl" />
+		</channels>
+	</channel-group-type>
+
+	<channel-group-type id="netMenuControls">
+		<label>Net/USB Menu</label>
+		<channels>
+			<channel id="title" typeId="title" />
+			<channel id="control" typeId="netControl" />
+			<channel id="item0" typeId="menuItem">
+				<label>Menu item 0</label>
+				<description>Net/USB menu item at position 0</description>
+			</channel>
+			<channel id="item1" typeId="menuItem">
+				<label>Menu item 1</label>
+				<description>Net/USB menu item at position 1</description>
+			</channel>
+			<channel id="item2" typeId="menuItem">
+				<label>Menu item 2</label>
+				<description>Net/USB menu item at position 2</description>
+			</channel>
+			<channel id="item3" typeId="menuItem">
+				<label>Menu item 3</label>
+				<description>Net/USB menu item at position 3</description>
+			</channel>
+			<channel id="item4" typeId="menuItem">
+				<label>Menu item 4</label>
+				<description>Net/USB menu item at position 4</description>
+			</channel>
+			<channel id="item5" typeId="menuItem">
+				<label>Menu item 5</label>
+				<description>Net/USB menu item at position 5</description>
+			</channel>
+			<channel id="item6" typeId="menuItem">
+				<label>Menu item 6</label>
+				<description>Net/USB menu item at position 6</description>
+			</channel>
+			<channel id="item7" typeId="menuItem">
+				<label>Menu item 7</label>
+				<description>Net/USB menu item at position 7</description>
+			</channel>
+			<channel id="item8" typeId="menuItem">
+				<label>Menu item 8</label>
+				<description>Net/USB menu item at position 8</description>
+			</channel>
+			<channel id="item9" typeId="menuItem">
+				<label>Menu item 9</label>
+				<description>Net/USB menu item at position 9</description>
+			</channel>
+			<channel id="selection" typeId="menuSelection" />
+		</channels>
+	</channel-group-type>
+
+</thing:thing-descriptions>

--- a/channels.xml
+++ b/channels.xml
@@ -1,0 +1,193 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<thing:thing-descriptions bindingId="onkyo" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:thing="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0"
+	xsi:schemaLocation="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0 http://eclipse.org/smarthome/schemas/thing-description-1.0.0.xsd">
+
+	<!-- Commands -->
+	<channel-type id="power">
+		<item-type>Switch</item-type>
+		<label>Power</label>
+		<description>Power on/off your device</description>
+	</channel-type>
+	<channel-type id="input">
+		<item-type>Number</item-type>
+		<label>Input Source</label>
+		<description>Select the input source of the AVR</description>
+		<state>
+			<options>
+				<option value="0">DVR/VCR</option>
+				<option value="1">SATELLITE/CABLE</option>
+				<option value="2">GAME</option>
+				<option value="3">AUX</option>
+				<option value="4">GAME2</option>
+				<option value="5">PC</option>
+				<option value="16">BLURAY/DVD</option>
+				<option value="17">STRM BOX</option>
+				<option value="18">TV</option>
+				<option value="32">TAPE1</option>
+				<option value="33">TAPE2</option>
+				<option value="34">PHONO</option>
+				<option value="35">CD/TV</option>
+				<option value="36">TUNER FM</option>
+				<option value="37">TUNER AM</option>
+				<option value="38">TUNER</option>
+				<option value="39">MUSICSERVER</option>
+				<option value="40">INTERNETRADIO</option>
+				<option value="41">USB</option>
+				<option value="42">USB_BACK</option>
+				<option value="43">NETWORK</option>
+				<option value="44">USB_TOGGLE</option>
+				<option value="45">AIRPLAY</option>
+				<option value="46">BLUETOOTH</option>
+				<option value="48">MULTICH</option>
+				<option value="50">SIRIUS</option>
+				<option value="128">SOURCE</option>
+			</options>
+		</state>
+	</channel-type>
+	<channel-type id="mute">
+		<item-type>Switch</item-type>
+		<label>Mute</label>
+		<description>Mute/unmute your device</description>
+	</channel-type>
+	<channel-type id="volume">
+		<item-type>Dimmer</item-type>
+		<label>Volume</label>
+		<description>Volume of your device</description>
+		<state min="0" max="100" step="1" pattern="%d %%">
+		</state>
+	</channel-type>
+	<channel-type id="volumedb" advanced="true">
+		<item-type>Number</item-type>
+		<label>Volume dB</label>
+		<description>Volume of your device (dB)</description>
+	    <state min="-82" max="0" step="0.5" pattern="%.1f dB">  
+		</state>
+	</channel-type>
+	<channel-type id="control" advanced="true">
+		<item-type>Player</item-type>
+		<label>Control</label>
+		<description>Control the Zone Player, e.g. start/stop/next/previous/ffward/rewind</description>
+		<category>Player</category>
+	</channel-type>
+	<channel-type id="listenmode" advanced="true">
+		<item-type>Number</item-type>
+		<label>Listen Mode</label>
+		<description>Listen mode</description>
+		<state>
+			<options>
+				<option value="0">Stereo</option>
+				<option value="1">Direct</option>
+				<option value="3">Game RPG</option>
+				<option value="5">Game Action</option>
+				<option value="6">Game Rock</option>
+				<option value="8">Orchestra</option>
+				<option value="9">unplugged</option>
+				<option value="10">Studio Mix</option>
+				<option value="11">TV Logic</option>
+				<option value="12">All Channel Stereo</option>
+				<option value="13">Theater Dimensional</option>
+				<option value="14">Game-Sports</option>
+				<option value="15">Mono</option>
+				<option value="17">Pure Audio</option>
+				<option value="19">Full Mono</option>
+				<option value="22">Audyssey DSX</option>
+				<option value="64">5.1ch Surround</option>
+				<option value="128">PLII/PLIIx Movie</option>
+				<option value="129">PLII/PLIIx Music</option>
+				<option value="130">Neo 6/Neo:X Cinema + DTS:X/Neural:X</option>
+				<option value="131">Neo 6/Neo:X Music</option>
+				<option value="134">PLII/PLIIx Game</option>
+				<option value="160">PLIIx/PLII Movie + Audyssey DSX</option>
+				<option value="161">PLIIx/PLII Music + Audyssey DSX</option>
+				<option value="162">PLIIx/PLII Game + Audyssey DSX</option>
+				<option value="163">Neo Cinema DSX</option>
+				<option value="164">Neo Music DSX</option>
+				<option value="165">Neural Surround DSX</option>
+				<option value="166">Neural Digital DSX</option>
+			</options>
+		</state>
+	</channel-type>
+	<channel-type id="playuri" advanced="true">
+		<item-type>String</item-type>
+		<label>Play URI</label>
+		<description>Plays a given URI</description>
+	</channel-type>
+	<channel-type id="netControl" advanced="true">
+		<item-type>String</item-type>
+		<label>Control</label>
+		<description>Control the USB/Net Menu, e.g. Up/Down/Select/Back/PageUp/PageDown/Select[0-9]</description>
+		<state>
+			<options>
+				<option value="Up">Selection Up</option>
+				<option value="Down">Selection Down</option>
+				<option value="Select">Select Entry</option>
+				<option value="Back">Go Back</option>
+				<option value="PageUp">Scroll Page Up</option>
+				<option value="PageDown">Scroll Page Down</option>
+				<option value="Select0">Select Entry 0</option>
+				<option value="Select1">Select Entry 1</option>
+				<option value="Select2">Select Entry 2</option>
+				<option value="Select3">Select Entry 3</option>
+				<option value="Select4">Select Entry 4</option>
+				<option value="Select5">Select Entry 5</option>
+				<option value="Select6">Select Entry 6</option>
+				<option value="Select7">Select Entry 7</option>
+				<option value="Select8">Select Entry 8</option>
+				<option value="Select9">Select Entry 9</option>
+			</options>
+		</state>
+	</channel-type>
+
+	<!-- Onkyo variables -->
+
+	<channel-type id="currentPlayingTime" advanced="true">
+		<item-type>String</item-type>
+		<label>Playing Time</label>
+		<description>Current Playing Time</description>
+		<state readOnly="true" pattern="%s"></state>
+	</channel-type>
+	<channel-type id="title" advanced="true">
+		<item-type>String</item-type>
+		<label>Title</label>
+		<description>Title of the current song</description>
+		<state readOnly="true" pattern="%s"></state>
+	</channel-type>
+	<channel-type id="album" advanced="true">
+		<item-type>String</item-type>
+		<label>Album</label>
+		<description>Album name of the current song</description>
+		<state readOnly="true" pattern="%s"></state>
+	</channel-type>
+	<channel-type id="albumArt" advanced="true">
+		<item-type>Image</item-type>
+		<label>Album Art</label>
+		<description>Image of cover art of the current song</description>
+		<state readOnly="true"></state>
+	</channel-type>
+	<channel-type id="albumArtUrl" advanced="true">
+		<item-type>String</item-type>
+		<label>Album Art Url</label>
+		<description>Url to the image of cover art of the current song</description>
+		<state readOnly="true"></state>
+	</channel-type>
+	<channel-type id="artist" advanced="true">
+		<item-type>String</item-type>
+		<label>Artist</label>
+		<description>Artist name of the current song</description>
+		<state readOnly="true" pattern="%s"></state>
+	</channel-type>
+	<channel-type id="menuItem" advanced="true">
+		<item-type>String</item-type>
+		<label>Menu item</label>
+		<description>Net/USB menu item</description>
+		<state readOnly="true" pattern="%s"></state>
+	</channel-type>
+	<channel-type id="menuSelection" advanced="true">
+		<item-type>Number</item-type>
+		<label>Selected Item</label>
+		<description>Position of the currently selected menu item</description>
+		<state readOnly="true" pattern="%s"></state>
+	</channel-type>
+
+</thing:thing-descriptions>

--- a/config.xml
+++ b/config.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<config-description:config-descriptions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:config-description="http://eclipse.org/smarthome/schemas/config-description/v1.0.0"
+	xsi:schemaLocation="http://eclipse.org/smarthome/schemas/config-description/v1.0.0
+		http://eclipse.org/smarthome/schemas/config-description-1.0.0.xsd">
+
+	<config-description uri="thing-type:onkyo:config">
+		<parameter name="ipAddress" type="text" required="true">
+			<label>Network Address</label>
+			<description>The IP or host name of the Onkyo Receiver</description>
+			<context>network-address</context>
+		</parameter>
+		<parameter name="port" type="integer" min="1" max="65335">
+			<label>Port</label>
+			<description>Port of the Onkyo to control</description>
+			<default>60128</default>
+			<advanced>true</advanced>
+		</parameter>
+		<parameter name="udn" type="text">
+			<label>Unique Device Name</label>
+			<description>The UDN identifies the Onkyo AVR.</description>
+			<advanced>true</advanced>
+		</parameter>
+		<parameter name="refreshInterval" type="integer" min="0">
+			<label>Refresh Interval</label>
+			<description>The refresh interval in seconds for polling the receiver (0=disable). Binding receive automatically updates from </description>
+			<default>0</default>
+			<advanced>true</advanced>
+		</parameter>
+		<parameter name="volumeLimit" type="integer" min="0" max="100">
+			<label>Volume Limit</label>
+			<description>Limit maximum volume level to defined value.</description>
+			<default>100</default>
+			<advanced>true</advanced>
+		</parameter>
+		<parameter name="volumedbLimit" type="integer" min="-82" max="0">
+			<label>Volume dB Limit</label>
+			<description>Limit maximum volume dB level to defined value.</description>
+			<default>0</default> 
+			<advanced>true</advanced>
+		</parameter>
+	</config-description>
+
+</config-description:config-descriptions>

--- a/vsx-1131.xml
+++ b/vsx-1131.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<thing:thing-descriptions bindingId="onkyo" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:thing="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0"
+	xsi:schemaLocation="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0 http://eclipse.org/smarthome/schemas/thing-description-1.0.0.xsd">
+
+	<thing-type id="VSX-1131">
+		<label>Pioneer VSX-1131 AV Receiver</label>
+		<description>Network enabled Pioneer AV Receivers</description>
+
+		<channel-groups>
+			<channel-group typeId="zone1Controls" id="zone1" />
+			<channel-group typeId="zone2Controls" id="zone2" />
+			<channel-group typeId="playerControls" id="player" />
+			<channel-group typeId="netMenuControls" id="netmenu" />
+		</channel-groups>
+
+		<config-description-ref uri="thing-type:onkyo:config" />
+	</thing-type>
+
+</thing:thing-descriptions>


### PR DESCRIPTION
[onkyo] volume dB support for newer Pioneer AVRs (e.g. VSX-1131)

see also issue #3509

Newer Pioneer AVRs (since 2015) also works with Onkyo protocol. But volume control works different to Onkyo: AVRs have a volume range from -82dB to 0dB and cannot controlled with the existing volume channels of the Onkyo binding (e.g. onkyo:onkyoAVR:myavr:zone1#volume) because type dimmer doesn't fit to this values.

My proposal is to add new channels "volumedb" as type number (for all three zones) and to convert the volume in OnkyoHandler.java.

I successfully tested it with my Pioneer VSX-1131. Necessary adjustments in the following files:
org.openhab.binding.onkyo_pioneer\README.md
org.openhab.binding.onkyo_pioneer\ESH-INF\thing\channel-groups.xml
org.openhab.binding.onkyo_pioneer\ESH-INF\thing\channels.xml
org.openhab.binding.onkyo_pioneer\ESH-INF\thing\vsx-1131.xml (new file)
org.openhab.binding.onkyo_pioneer\src\main\java\org\openhab\binding\onkyo\OnkyoBindingConstants.java
onkyo_backup\org.openhab.binding.onkyo_pioneer\ESH-INF\config\config.xml
onkyo_backup\org.openhab.binding.onkyo_pioneer\src\main\java\org\openhab\binding\onkyo\handler\OnkyoHandler.java
onkyo_backup\org.openhab.binding.onkyo_pioneer\src\main\java\org\openhab\binding\onkyo\internal\config\OnkyoDeviceConfiguration.java
